### PR TITLE
feat: make `chainId` optional

### DIFF
--- a/ERCS/erc-7846.md
+++ b/ERCS/erc-7846.md
@@ -69,7 +69,6 @@ const response = await provider.request({
     capabilities: {
       signInWithEthereum: {
         nonce: '12345678',
-        chainId: '0x1'
       }
     }
   }]
@@ -135,7 +134,7 @@ The wallet MUST return a ERC-4361-formatted message that exactly matches the req
 type Parameters = {
   signInWithEthereum: {
     nonce: string;
-    chainId: string; // EIP-155 hex-encoded
+    chainId?: string; // EIP-155 hex-encoded
     version?: string;
     scheme?: string;
     domain?: string;


### PR DESCRIPTION
Makes `chainId` optional.

Rationale: App ends up fetching this from the Wallet 99% of the time (and the Wallet already knows its account's base chain), so we can save a round-trip.